### PR TITLE
fix bug in DAPI plate error where well was too long for db col

### DIFF
--- a/plaque_assay/plate.py
+++ b/plaque_assay/plate.py
@@ -136,7 +136,7 @@ class Plate:
                     well_names = "multiple wells (>8)"
                 failed_plate = failure.PlateFailure(
                     plate=self.barcode,
-                    well="multiple wells (>8)",
+                    well=well_names,
                     failure_reason=failure.DAPI_PLATE_FAILURE_REASON,
                 )
                 self.plate_failures.add(failed_plate)


### PR DESCRIPTION
When there are too many DAPI failure wells, the concatenated string is too long for `NE_failed_results.well` (varchar(45)). This checks the length of the concatenated string and replaces it with `"multiple wells (>8)"` if necessary.